### PR TITLE
Flag for outputting a raw C array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "pigment"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "png",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pigment"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ struct Args {
 
     /// Overrides the natural fit of each format when outputting a C array
     #[arg(short, long, value_enum)]
-    type_width: Option<TypeWideArray>,
+    type_width: Option<TypeWidthArray>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, ValueEnum, Debug)]
@@ -52,7 +52,7 @@ enum Format {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, ValueEnum, Debug)]
-enum TypeWideArray {
+enum TypeWidthArray {
     U8,
     U16,
     U32,
@@ -60,18 +60,18 @@ enum TypeWideArray {
 }
 
 impl Format {
-    fn get_width(&self) -> TypeWideArray {
+    fn get_width(&self) -> TypeWidthArray {
         match self {
-            Format::Ci4 => TypeWideArray::U8,
-            Format::Ci8 => TypeWideArray::U8,
-            Format::I4 => TypeWideArray::U8,
-            Format::I8 => TypeWideArray::U8,
-            Format::Ia4 => TypeWideArray::U8,
-            Format::Ia8 => TypeWideArray::U8,
-            Format::Ia16 => TypeWideArray::U16,
-            Format::Rgba16 => TypeWideArray::U16,
-            Format::Rgba32 => TypeWideArray::U32,
-            Format::Palette => TypeWideArray::U16,
+            Format::Ci4 => TypeWidthArray::U8,
+            Format::Ci8 => TypeWidthArray::U8,
+            Format::I4 => TypeWidthArray::U8,
+            Format::I8 => TypeWidthArray::U8,
+            Format::Ia4 => TypeWidthArray::U8,
+            Format::Ia8 => TypeWidthArray::U8,
+            Format::Ia16 => TypeWidthArray::U16,
+            Format::Rgba16 => TypeWidthArray::U16,
+            Format::Rgba32 => TypeWidthArray::U32,
+            Format::Palette => TypeWidthArray::U16,
         }
     }
 }
@@ -165,10 +165,10 @@ fn main() {
         type_width = args.type_width.unwrap_or(type_width);
 
         match type_width {
-            TypeWideArray::U8 => write_buf_as_u8(&mut output_file, &bin),
-            TypeWideArray::U16 => write_buf_as_u16(&mut output_file, &bin),
-            TypeWideArray::U32 => write_buf_as_u32(&mut output_file, &bin),
-            TypeWideArray::U64 => write_buf_as_u64(&mut output_file, &bin),
+            TypeWidthArray::U8 => write_buf_as_u8(&mut output_file, &bin),
+            TypeWidthArray::U16 => write_buf_as_u16(&mut output_file, &bin),
+            TypeWidthArray::U32 => write_buf_as_u32(&mut output_file, &bin),
+            TypeWidthArray::U64 => write_buf_as_u64(&mut output_file, &bin),
         }
     } else {
         BufWriter::new(output_file)

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,7 @@ fn main() {
             Format::Palette => type_width = TypeWideArray::U16,
         }
 
-        // Override if the user passed the appropiate flag
+        // Override if the user passed the appropriate flag
         type_width = args.type_width.unwrap_or(type_width);
 
         match type_width {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct Args {
     #[arg(long)]
     flip_y: bool,
 
-    /// Output a raw C array which can be `#include`d in a file. The default output type width matches the FORMAT provided, but it can be fine-tuned with --type-width
+    /// Output a raw C array which can be `#include`d in a file. The default output type width matches the FORMAT provided, but it can be overridden with --type-width
     #[arg(short, long)]
     c_array: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,13 +27,13 @@ struct Args {
     #[arg(long)]
     flip_y: bool,
 
-    /// Output a raw C array which can be `#include` in a file. The default output type width matches the FORMAT provided, but it can be fine-tunned with --type-width
+    /// Output a raw C array which can be `#include`d in a file. The default output type width matches the FORMAT provided, but it can be fine-tuned with --type-width
     #[arg(short, long)]
     c_array: bool,
 
     /// Overrides the natural fit of each format when outputting a C array
     #[arg(short, long, value_enum)]
-    type_wide: Option<TypeWideArray>,
+    type_width: Option<TypeWideArray>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, ValueEnum, Debug)]
@@ -179,26 +179,26 @@ fn main() {
     let mut output_file = File::create(output_path).expect("could not create output file");
 
     if args.c_array {
-        let mut type_wide: TypeWideArray;
+        let mut type_width: TypeWideArray;
 
         // Compute the default value first
         match args.format {
-            Format::Ci4 => type_wide = TypeWideArray::U8,
-            Format::Ci8 => type_wide = TypeWideArray::U8,
-            Format::I4 => type_wide = TypeWideArray::U8,
-            Format::I8 => type_wide = TypeWideArray::U8,
-            Format::Ia4 => type_wide = TypeWideArray::U8,
-            Format::Ia8 => type_wide = TypeWideArray::U8,
-            Format::Ia16 => type_wide = TypeWideArray::U16,
-            Format::Rgba16 => type_wide = TypeWideArray::U16,
-            Format::Rgba32 => type_wide = TypeWideArray::U32,
-            Format::Palette => type_wide = TypeWideArray::U16,
+            Format::Ci4 => type_width = TypeWideArray::U8,
+            Format::Ci8 => type_width = TypeWideArray::U8,
+            Format::I4 => type_width = TypeWideArray::U8,
+            Format::I8 => type_width = TypeWideArray::U8,
+            Format::Ia4 => type_width = TypeWideArray::U8,
+            Format::Ia8 => type_width = TypeWideArray::U8,
+            Format::Ia16 => type_width = TypeWideArray::U16,
+            Format::Rgba16 => type_width = TypeWideArray::U16,
+            Format::Rgba32 => type_width = TypeWideArray::U32,
+            Format::Palette => type_width = TypeWideArray::U16,
         }
 
         // Override if the user passed the appropiate flag
-        type_wide = args.type_wide.unwrap_or(type_wide);
+        type_width = args.type_width.unwrap_or(type_width);
 
-        match type_wide {
+        match type_width {
             TypeWideArray::U8 => write_buf_as_u8(&mut output_file, &bin),
             TypeWideArray::U16 => write_buf_as_u16(&mut output_file, &bin),
             TypeWideArray::U32 => write_buf_as_u32(&mut output_file, &bin),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, ValueEnum};
 use std::fs::File;
-use std::io::{BufReader, BufWriter};
 use std::io::prelude::*;
+use std::io::{BufReader, BufWriter};
 use std::path::PathBuf;
 
 /// PNG to N64 image converter
@@ -130,7 +130,9 @@ fn write_buf_as_u64(output_file: &mut File, bin: &Vec<u8>) {
                 write!(output_file, " ").expect("could not write to output file");
             }
 
-            let value = u64::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]]);
+            let value = u64::from_be_bytes([
+                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+            ]);
 
             write!(output_file, "0x{value:016X},").expect("could not write to output file");
 
@@ -179,7 +181,7 @@ fn main() {
     let mut output_file = File::create(output_path).expect("could not create output file");
 
     if args.c_array {
-        let mut type_wide : TypeWideArray;
+        let mut type_wide: TypeWideArray;
 
         // Compute the default value first
         match args.format {
@@ -209,5 +211,4 @@ fn main() {
             .write_all(&bin)
             .expect("could not write to output file");
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,83 +60,61 @@ enum TypeWideArray {
 
 fn write_buf_as_u8(output_file: &mut File, bin: &Vec<u8>) {
     for row in bin.chunks(16) {
-        write!(output_file, "    ").expect("could not write to output file");
+        let mut line_list = Vec::new();
 
-        let mut printed_first = false;
+        for bytes in row.chunks(1) {
+            let value = u8::from_be_bytes(bytes.try_into().unwrap());
 
-        for byte in row {
-            if printed_first {
-                write!(output_file, " ").expect("could not write to output file");
-            }
-
-            write!(output_file, "0x{byte:02X},").expect("could not write to output file");
-
-            printed_first = true;
+            line_list.push(format!("0x{value:02X}"));
         }
-        write!(output_file, "\n").expect("could not write to output file");
+
+        let line = line_list.join(", ");
+        write!(output_file, "    {line},\n").expect("could not write to output file");
     }
 }
 
 fn write_buf_as_u16(output_file: &mut File, bin: &Vec<u8>) {
     for row in bin.chunks(16) {
-        write!(output_file, "    ").expect("could not write to output file");
-
-        let mut printed_first = false;
+        let mut line_list = Vec::new();
 
         for bytes in row.chunks(2) {
-            if printed_first {
-                write!(output_file, " ").expect("could not write to output file");
-            }
-
             let value = u16::from_be_bytes(bytes.try_into().unwrap());
 
-            write!(output_file, "0x{value:04X},").expect("could not write to output file");
-
-            printed_first = true;
+            line_list.push(format!("0x{value:04X}"));
         }
-        write!(output_file, "\n").expect("could not write to output file");
+
+        let line = line_list.join(", ");
+        write!(output_file, "    {line},\n").expect("could not write to output file");
     }
 }
 
 fn write_buf_as_u32(output_file: &mut File, bin: &Vec<u8>) {
     for row in bin.chunks(16) {
-        write!(output_file, "    ").expect("could not write to output file");
-
-        let mut printed_first = false;
+        let mut line_list = Vec::new();
 
         for bytes in row.chunks(4) {
-            if printed_first {
-                write!(output_file, " ").expect("could not write to output file");
-            }
-
             let value = u32::from_be_bytes(bytes.try_into().unwrap());
 
-            write!(output_file, "0x{value:08X},").expect("could not write to output file");
-
-            printed_first = true;
+            line_list.push(format!("0x{value:08X}"));
         }
-        write!(output_file, "\n").expect("could not write to output file");
+
+        let line = line_list.join(", ");
+        write!(output_file, "    {line},\n").expect("could not write to output file");
     }
 }
 
 fn write_buf_as_u64(output_file: &mut File, bin: &Vec<u8>) {
     for row in bin.chunks(16) {
-        write!(output_file, "    ").expect("could not write to output file");
-
-        let mut printed_first = false;
+        let mut line_list = Vec::new();
 
         for bytes in row.chunks(8) {
-            if printed_first {
-                write!(output_file, " ").expect("could not write to output file");
-            }
-
             let value = u64::from_be_bytes(bytes.try_into().unwrap());
 
-            write!(output_file, "0x{value:016X},").expect("could not write to output file");
-
-            printed_first = true;
+            line_list.push(format!("0x{value:016X}"));
         }
-        write!(output_file, "\n").expect("could not write to output file");
+
+        let line = line_list.join(", ");
+        write!(output_file, "    {line},\n").expect("could not write to output file");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn write_buf_as_u16(output_file: &mut File, bin: &Vec<u8>) {
                 write!(output_file, " ").expect("could not write to output file");
             }
 
-            let value = u16::from_be_bytes([bytes[0], bytes[1]]);
+            let value = u16::from_be_bytes(bytes.try_into().unwrap());
 
             write!(output_file, "0x{value:04X},").expect("could not write to output file");
 
@@ -109,7 +109,7 @@ fn write_buf_as_u32(output_file: &mut File, bin: &Vec<u8>) {
                 write!(output_file, " ").expect("could not write to output file");
             }
 
-            let value = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            let value = u32::from_be_bytes(bytes.try_into().unwrap());
 
             write!(output_file, "0x{value:08X},").expect("could not write to output file");
 
@@ -130,9 +130,7 @@ fn write_buf_as_u64(output_file: &mut File, bin: &Vec<u8>) {
                 write!(output_file, " ").expect("could not write to output file");
             }
 
-            let value = u64::from_be_bytes([
-                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
-            ]);
+            let value = u64::from_be_bytes(bytes.try_into().unwrap());
 
             write!(output_file, "0x{value:016X},").expect("could not write to output file");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,18 +85,21 @@ fn main() {
     let mut output_file = File::create(output_path).expect("could not create output file");
 
     if args.c_array {
-        let mut bytes_writen = 0;
+        for row in bin.chunks(16) {
+            write!(output_file, "    ").expect("c");
 
-        for byte in bin {
-            write!(output_file, "0x{byte:02X}, ").expect("oy noy, stuff failed");
+            let mut printed_first = false;
 
-            bytes_writen += 1;
+            for byte in row {
+                if printed_first {
+                    write!(output_file, " ").expect("asdf");
+                }
 
-            if bytes_writen >= 8 {
-                bytes_writen = 0;
+                write!(output_file, "0x{byte:02X},").expect("oy noy, stuff failed");
 
-                write!(output_file, "\n").expect("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+                printed_first = true;
             }
+            write!(output_file, "\n").expect("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         }
     } else {
         BufWriter::new(output_file)

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,23 @@ enum TypeWideArray {
     U64,
 }
 
+impl Format {
+    fn get_width(&self) -> TypeWideArray {
+        match self {
+            Format::Ci4 => TypeWideArray::U8,
+            Format::Ci8 => TypeWideArray::U8,
+            Format::I4 => TypeWideArray::U8,
+            Format::I8 => TypeWideArray::U8,
+            Format::Ia4 => TypeWideArray::U8,
+            Format::Ia8 => TypeWideArray::U8,
+            Format::Ia16 => TypeWideArray::U16,
+            Format::Rgba16 => TypeWideArray::U16,
+            Format::Rgba32 => TypeWideArray::U32,
+            Format::Palette => TypeWideArray::U16,
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! write_buf_as_raw_array {
     ($dst:expr, $bin:expr, $type_width:ident) => {
@@ -132,21 +149,7 @@ fn main() {
     let mut output_file = File::create(output_path).expect("could not create output file");
 
     if args.c_array {
-        let mut type_width: TypeWideArray;
-
-        // Compute the default value first
-        match args.format {
-            Format::Ci4 => type_width = TypeWideArray::U8,
-            Format::Ci8 => type_width = TypeWideArray::U8,
-            Format::I4 => type_width = TypeWideArray::U8,
-            Format::I8 => type_width = TypeWideArray::U8,
-            Format::Ia4 => type_width = TypeWideArray::U8,
-            Format::Ia8 => type_width = TypeWideArray::U8,
-            Format::Ia16 => type_width = TypeWideArray::U16,
-            Format::Rgba16 => type_width = TypeWideArray::U16,
-            Format::Rgba32 => type_width = TypeWideArray::U32,
-            Format::Palette => type_width = TypeWideArray::U16,
-        }
+        let mut type_width = args.format.get_width();
 
         // Override if the user passed the appropriate flag
         type_width = args.type_width.unwrap_or(type_width);

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,64 +58,35 @@ enum TypeWideArray {
     U64,
 }
 
-fn write_buf_as_u8(output_file: &mut File, bin: &Vec<u8>) {
-    for row in bin.chunks(16) {
-        let mut line_list = Vec::new();
-
-        for bytes in row.chunks(1) {
-            let value = u8::from_be_bytes(bytes.try_into().unwrap());
-
-            line_list.push(format!("0x{value:02X}"));
+#[macro_export]
+macro_rules! write_buf_as_raw_array {
+    ($dst:expr, $bin:expr, $width:expr, $callback:expr) => {
+        for row in $bin.chunks(16) {
+            let mut line_list = Vec::new();
+            for bytes in row.chunks($width) {
+                let value = $callback(bytes.try_into().unwrap());
+                line_list.push(format!("0x{value:00$X}", 2*$width));
+            }
+            let line = line_list.join(", ");
+            write!($dst, "    {line},\n").expect("could not write to output file");
         }
-
-        let line = line_list.join(", ");
-        write!(output_file, "    {line},\n").expect("could not write to output file");
     }
+}
+
+fn write_buf_as_u8(output_file: &mut File, bin: &Vec<u8>) {
+    write_buf_as_raw_array!(output_file, bin, 1, u8::from_be_bytes);
 }
 
 fn write_buf_as_u16(output_file: &mut File, bin: &Vec<u8>) {
-    for row in bin.chunks(16) {
-        let mut line_list = Vec::new();
-
-        for bytes in row.chunks(2) {
-            let value = u16::from_be_bytes(bytes.try_into().unwrap());
-
-            line_list.push(format!("0x{value:04X}"));
-        }
-
-        let line = line_list.join(", ");
-        write!(output_file, "    {line},\n").expect("could not write to output file");
-    }
+    write_buf_as_raw_array!(output_file, bin, 2, u16::from_be_bytes);
 }
 
 fn write_buf_as_u32(output_file: &mut File, bin: &Vec<u8>) {
-    for row in bin.chunks(16) {
-        let mut line_list = Vec::new();
-
-        for bytes in row.chunks(4) {
-            let value = u32::from_be_bytes(bytes.try_into().unwrap());
-
-            line_list.push(format!("0x{value:08X}"));
-        }
-
-        let line = line_list.join(", ");
-        write!(output_file, "    {line},\n").expect("could not write to output file");
-    }
+    write_buf_as_raw_array!(output_file, bin, 4, u32::from_be_bytes);
 }
 
 fn write_buf_as_u64(output_file: &mut File, bin: &Vec<u8>) {
-    for row in bin.chunks(16) {
-        let mut line_list = Vec::new();
-
-        for bytes in row.chunks(8) {
-            let value = u64::from_be_bytes(bytes.try_into().unwrap());
-
-            line_list.push(format!("0x{value:016X}"));
-        }
-
-        let line = line_list.join(", ");
-        write!(output_file, "    {line},\n").expect("could not write to output file");
-    }
+    write_buf_as_raw_array!(output_file, bin, 8, u64::from_be_bytes);
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,12 +142,16 @@ fn main() {
 
     let mut output_file: Box<dyn Write>;
 
-    if args.c_array {
+    if args.c_array && args.output.is_none() {
         output_file = Box::from(io::stdout());
     } else {
         let output_path = PathBuf::from(args.output.unwrap_or_else(|| {
             let mut path = args.input.clone();
-            path.push_str(".bin");
+            if args.c_array {
+                path.push_str(".inc.c");
+            } else {
+                path.push_str(".bin");
+            }
             path
         }));
 


### PR DESCRIPTION
Adds the new `-c`/`--c-array` flag, which allows outputting the raw contents of a C array.

The default type width changes depending on the input format, using:
- `u8` for `ci4`, `ci8`, `i4`, `i8`, `ia4` and `ia8`
- `u16` for `ia16`, `rgba16` and `palette`
- `u32` for `rgba32`

This automatic type width can be overridden with the `-t`/`--type-width` flag, which allows for `u8`, `u16`. `u32` and `u64`.

I'm not sure if I should leave the write functions in the `main.rs` file or in the `lib.rs` one. Tell me if I should move them

Addresses #1 
